### PR TITLE
Fixed small account statistics bug

### DIFF
--- a/pages/account.js
+++ b/pages/account.js
@@ -180,7 +180,7 @@ export default function account() {
                   </Col>
                   <Col md={6} className="text-end">
                     {/* Change this: */}
-                    <Badge className="px-3 pt-2 pb-2 bg-secondary">{user.recipes.length}</Badge>
+                    <Badge className="px-3 pt-2 pb-2 bg-secondary">{user ? user.recipes.length : 0}</Badge>
                   </Col>
                 </Row>
               </Container>
@@ -211,7 +211,7 @@ export default function account() {
                   </Col>
                   <Col md={6} className="text-end">
                     {/* Change this: */}
-                    <Badge className="px-3 pt-2 pb-2 bg-secondary">{user.generatedRecipes}</Badge>
+                    <Badge className="px-3 pt-2 pb-2 bg-secondary">{user ? user.generatedRecipes : 0}</Badge>
                   </Col>
                 </Row>
               </Container>


### PR DESCRIPTION
## Summary
Hey @kpunno, found a small bug for displaying account statistics. Occasionally, I get an error (Shown in screenshot) stating that user is null. I believe this error was caused due to loading the account statistics page too fast to the point where it couldn't grab the users information in time. Therefore, I fixed it by giving both _Number of saved recipes_ and _Number of generated recipes_ default value (i.e. `{user ? user.recipes.length : 0}`).

## Fix
Give account statistics a default value to display before getting the users actual values. Getting rid of any errors that may occur if the user tries to get their account statistics too fast.

## Screenshot

![image](https://github.com/rjwignar/AIChefBot/assets/97624401/39fa814d-b27c-48a1-9fe7-b17f0df21029)
