### PR TITLE
Delete recipe fix

### DIFF
--- a/components/RecipeCard.js
+++ b/components/RecipeCard.js
@@ -98,7 +98,7 @@ const RecipeCard = ({ recipe, onDelete, onSelect, isSelected, isSelectable }) =>
          headers: {
             "Content-Type": "application/json"
          },
-         body: JSON.stringify({userId: session.user.id, recipeIds: savedId}),
+         body: JSON.stringify({userId: session.user.id, recipeIds: [savedId]}),
       })
       setSavedId(null);
       setShowModal(false);


### PR DESCRIPTION
Now sends `recipeIds` as an array, since the route accepts either one or multiple `_ids`.