### PR TITLE
add env var to disable image generation

### DIFF
--- a/pages/api/generateRecipeUtils.js
+++ b/pages/api/generateRecipeUtils.js
@@ -1,5 +1,6 @@
 import OpenAI from 'openai';
 import { generateRecipeImages } from './generateImageUtils';
+
 // This is how many recipes will be generated at a time. This may change once the generated recipes view is finalized
 const recipeCount = 3;
 
@@ -106,7 +107,12 @@ export async function generateRecipes(prompt, messageHistory) {
         let recipes = messageContent.recipes;
 
         // Use an OpenAI DALL-E model to generate an appropriate image and add an imageURL property to each recipe
-        recipes = await generateRecipeImages(recipes);
+        if (process.env.GENERATE_IMAGES == "OFF") {
+            console.log("IMAGE GENERATION IS DISABLED");
+        }
+        else {
+            recipes = await generateRecipeImages(recipes);
+        }
 
         // Console Logging
         console.log("Generated Recipes Below", recipes);


### PR DESCRIPTION
In your `.env` file, you can optionally add the variable

```
GENERATE_IMAGES=OFF
```

This will disable requests to the API, so we can save money. It seems next.js natively supports loading of environment variables into the runtime, so we don't need to use `dotenv`.