### PR TITLE
Update sorting saved recipes method to use "created" attribute

### DIFF
--- a/pages/account/recipes.js
+++ b/pages/account/recipes.js
@@ -62,15 +62,20 @@ export default function recipes() {
     }
   }, []);
 
-  // Sorts the recipes based on least or most recent.
+  // Sorts the recipes based on most or least recent.
   useEffect(() => {
     if (recipes) {
       let sortedFilteredRecipes = [...filteredRecipes];
-      if (isSortedMostRecent) {
-        sortedFilteredRecipes.reverse();
-      } else {
-        sortedFilteredRecipes = [...recipes];
-      }
+      
+      
+      // Sort the recipes based on the "created" attribute
+      sortedFilteredRecipes.sort((a, b) => {
+        // Convert the date strings to Date objects for reliable comparison
+        let dateA = new Date(a.created);
+        let dateB = new Date(b.created);
+        // Determine sort order based on the isSortedMostRecent flag
+        return isSortedMostRecent ? dateB - dateA : dateA - dateB;
+      });
       setFilteredRecipes(sortedFilteredRecipes);
     }
   }, [isSortedMostRecent, recipes]);  


### PR DESCRIPTION
This fixes #201 

## Summary
Instead of reversing the array like we did before, I used the new `created` attribute to sort them.

**Sorting by newest (Shows same date but they were saved at different times.**
![image](https://github.com/rjwignar/AIChefBot/assets/97624401/146321b3-28f8-4353-acc5-1836f12d7b61)

**Sorting by oldest.**
![image](https://github.com/rjwignar/AIChefBot/assets/97624401/ae69191d-f2b1-4b54-94d8-56c9c7081f87)

