### PR TITLE
Simple fix for the date badge bug from generate similar recipes scenario

### DIFF
--- a/components/RecipeCard.js
+++ b/components/RecipeCard.js
@@ -163,7 +163,7 @@ const RecipeCard = ({ recipe, onDelete, onSelect, isSelected, isSelectable }) =>
             <Card.Img className='recipe-card-img' variant="top" src={recipe.imageURL || recipe.tempImageURL || 'https://i.imgur.com/iTpOC92.jpeg'}/>
             <Card.Body className='p-3'>
                <Card.Title className='recipe-card-title mt-2'>{recipe.name}</Card.Title>
-               {router.asPath == '/account/recipes' && 
+               {router.asPath == '/account/recipes' && recipe.created && 
                   <Badge className={"bg-success bg-opacity-75"}>
                      Created:&nbsp;
                      {new Date(recipe.created).toLocaleDateString()}


### PR DESCRIPTION
This fixes #197 

## Summary
As pointed out by @rjwignar, when testing generate similar recipes, the date badge still appears with the created date being `Invalid Date`
![322063444-fb94fde7-f77c-41db-b2ba-ab7732e1fa1d](https://github.com/rjwignar/AIChefBot/assets/97624401/c2dd0e09-31ff-4af4-9c60-f6999c64cf43)

This hopefully fixes the issue for now.